### PR TITLE
Fix error in not considering the result of the second argument of <*

### DIFF
--- a/src/microparsec/primitives.nim
+++ b/src/microparsec/primitives.nim
@@ -97,10 +97,14 @@ func `<$`*[S, T](x: T, parser: Parser[S]): Parser[T] {.inline.} =
   parser.map constant[S, T]x
 
 func `<*`*[T, S](parser0: Parser[T], parser1: Parser[S]): Parser[T] {.inline.} =
-  return func(state: ParseState): ParseResult[T] =
-    result = parser0 state
-    if result.isOk:
-      discard parser1 state
+  return proc(state: ParseState): ParseResult[T] =
+             let r0: ParseResult[T] = parser0 state
+             if r0.isOk:
+               let r1: ParseResult[S] = parser1 state
+               return if r1.isOk: r0
+                      else: fail[T](r1)
+             else:
+               return r0
 
 func `*>`*[S, T](parser0: Parser[S], parser1: Parser[T]): Parser[T] {.inline.} =
   return func(state: ParseState): ParseResult[T] =

--- a/tests/test_basics.nim
+++ b/tests/test_basics.nim
@@ -234,7 +234,7 @@ suite "parser combinators":
   test "<*":
     let p = ch('a') <* ch('-')
     check p.debugParse("a-") == $('a', "")
-    check p.debugParse("aa-") == $('a', "a-")
+    check p.debugParse("aa-") == $(unexpected: "\'a\'", expected: @["\'-\'"])
     check p.debugParse("b-") == $(unexpected: "\'b\'", expected: @["\'a\'"])
     check p.debugParse("-") == $(unexpected: "\'-\'", expected: @["\'a\'"])
     check p.debugParse("") == $(unexpected: "end of input", expected: @[


### PR DESCRIPTION
Previous implementation was discarding the Result[T] for <*, which meant that writing
```nim
many(digit) <* eof
```
did also match `8394   483` because the eof would fail but such result would be discarded.

Instead what we want is to also try to parse the second result and if it fails then we return a failure,
otherwise we return only the first correctly parsed result.